### PR TITLE
Backwards compatibile fix for new ckminions output in Salt 2018

### DIFF
--- a/pillar/vault.py
+++ b/pillar/vault.py
@@ -262,7 +262,11 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
     # Apply the compound filters to determine which secrets to expose for this minion
     ckminions = salt.utils.minions.CkMinions(__opts__)
     for filter, secrets in secret_map.items():
-        if minion_id in ckminions.check_minions(filter, "compound"):
+        minions =  ckminions.check_minions(filter, "compound")
+        if 'minions' in minions:
+            # In Salt 2018 this is now in a kwarg
+            minions = minions['minions']
+        if minion_id in minions:
             for variable, location in secrets.items():
                 return_data = couple(location, conn)
                 if return_data:


### PR DESCRIPTION
Salt 2018 behavior changed for ckminions output. New behavior places the minions in a key called 'minions'. Checking for the 'minions' key keeps this backwards compatible with previous salt versions.